### PR TITLE
Remove blank keys

### DIFF
--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -317,7 +317,12 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 			-- Parse the typed values into dictionary based on the header row keys
 			local Value = table.create(#Components)
 			for i, Comp in ipairs(Components) do
-				Value[ColumnToKey[i]] = ConvertTyped(Comp)
+				local key = ColumnToKey[i]	
+				local typedComp = ConvertTyped(Comp)
+									
+				if (key == "") then continue end									
+													
+				Value[key] = typedComp
 			end
 
 			local Name = Value.Name or Value.name or string.format("%d", Row) -- Index by name, or by row if no names exist


### PR DESCRIPTION
With the spreadsheet setup below, I was receiving dictionaries with an extra key/value pair in which both the key and value were an empty string (also imaged below).  Proposed changes will skip the iteration if the key is a blank string.  I thought about checking if the value was an empty string, but the end user may want that behavior.

![image](https://user-images.githubusercontent.com/5618200/114181162-25a40f00-990f-11eb-9b1b-84a09fd318fc.png)
![image](https://user-images.githubusercontent.com/5618200/114181209-35bbee80-990f-11eb-9862-9957ba0c690c.png)
