### PR TITLE
Inherent Types and Arbitrary Properties

### DIFF
--- a/SheetValues/TypeTransformer.lua
+++ b/SheetValues/TypeTransformer.lua
@@ -64,7 +64,7 @@ return {
 		return Color3.new(
 			tonumber(comps[1]) or 0,
 			tonumber(comps[2]) or 0,
-			tonumber(comps[3]) or 0,
+			tonumber(comps[3]) or 0
 		)
 	end,
 	["brickcolor"] = function(v)
@@ -75,7 +75,7 @@ return {
 		return Color3.fromRGB(
 			tonumber(comps[1]) or 0,
 			tonumber(comps[2]) or 0,
-			tonumber(comps[3]) or 0,
+			tonumber(comps[3]) or 0
 		)
 	end,
 	["cframe"] = function(v)
@@ -83,7 +83,7 @@ return {
 		return CFrame.new(
 			tonumber(comps[1]) or 0,
 			tonumber(comps[2]) or 0,
-			tonumber(comps[3]) or 0,
+			tonumber(comps[3]) or 0
 		)
 	end,
 	["enum"] = function(v)

--- a/SheetValues/TypeTransformer.lua
+++ b/SheetValues/TypeTransformer.lua
@@ -59,4 +59,44 @@ return {
 			tonumber(comps[2]) or 0
 		)
 	end,
+	["color3"] = function(v)
+		local comps = string.split(v,",")
+		return Color3.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0,
+			tonumber(comps[3]) or 0,
+		)
+	end,
+	["brickcolor"] = function(v)
+		return BrickColor.new(v)
+	end,
+	["rgb"] = function(v)
+		local comps = string.split(v,",")
+		return Color3.fromRGB(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0,
+			tonumber(comps[3]) or 0,
+		)
+	end,
+	["cframe"] = function(v)
+		local comps = string.split(v,",")
+		return CFrame.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0,
+			tonumber(comps[3]) or 0,
+		)
+	end,
+	["enum"] = function(v)
+		local comps = string.split(v,".")
+		return Enum[comps[1]][comps[2]]
+	end,
+	["rect"] = function(v)
+		local comps = string.split(v,",")
+		return Rect.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0,
+			tonumber(comps[3]) or 0,
+			tonumber(comps[4]) or 0
+		)
+	end,
 }

--- a/SheetValues/TypeTransformer.lua
+++ b/SheetValues/TypeTransformer.lua
@@ -1,0 +1,62 @@
+--[[
+	TypeTransformers are functions that take in a entry of the CSV as a string,
+	and then transform it into the desired datatype.
+	Note that dict keys in here must be entirely lowercase.
+]]
+
+return {
+	["string"] = function(v)
+		return tostring(v)
+	end,
+	["number"] = function(v)
+		return tonumber(v)
+	end,
+	["boolean"] = function(v)
+		return string.lower(v)=="true" and true or false
+	end,
+	["array"] = function(v)
+		return string.split(v,",")
+	end,
+	["dictionary"] = function(v)
+		local values = string.split(v,",")
+		local dict = table.create(#values)
+
+		for _,value in ipairs(values) do
+			local components = string.split(value,"=")
+			dict[string.gsub(string.gsub(components[1],"^ ","")," $","")] = string.gsub(components[2],"^ ","")
+		end
+
+		return dict
+	end,
+	["vector3"] = function(v)
+		local comps = string.split(v,",")
+		return Vector3.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0,
+			tonumber(comps[3]) or 0
+		)
+	end,
+	["vector2"] = function(v)
+		local comps = string.split(v,",")
+		return Vector2.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0
+		)
+	end,
+	["udim2"] = function(v)
+		local comps = string.split(v,",")
+		return UDim2.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0,
+			tonumber(comps[3]) or 0,
+			tonumber(comps[4]) or 0
+		)
+	end,
+	["udim"] = function(v)
+		local comps = string.split(v,",")
+		return UDim.new(
+			tonumber(comps[1]) or 0,
+			tonumber(comps[2]) or 0
+		)
+	end,
+}

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -317,7 +317,12 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 			-- Parse the typed values into dictionary based on the header row keys
 			local Value = table.create(#Components)
 			for i, Comp in ipairs(Components) do
-				Value[ColumnToKey[i]] = ConvertTyped(Comp)
+				local key = ColumnToKey[i]	
+				local typedComp = ConvertTyped(Comp)
+									
+				if (key == "") then continue end									
+													
+				Value[key] = typedComp
 			end
 
 			local Name = Value.Name or Value.name or string.format("%d", Row) -- Index by name, or by row if no names exist

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -29,9 +29,11 @@
 	a SheetManager linked to that sheet. Note that the SheetId parameter is optional and will default to
 	the first (or only) sheet in your spread.
 
-	What should your Google Sheet look like? How does it translate into Values? Here's the structure:
+	What should your Google Sheet look like?
+	Well, rows are turned into Values with each column entry being a Property of the Value.
+	Here's the structure:
 	The first row of the Sheet is the Header. This row will NOT become a Value, rather it defines how we parse
-	the subsequent rows into Values. Each entry into row 1 becomes the key for that column, which is called a Property.
+	the subsequent rows into Values. Each entry into row 1 becomes the key for that column (Property).
 
 	Example:
 	Name          PropertyName     AnotherProp

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -217,11 +217,21 @@ local function DictEquals(a, b)
 	if type(a) ~= type(b) then return false end
 
 	for k, v in pairs(a) do
-		if b[k] ~= v then return false end
+		if (type(v)=="table") and (not DictEquals(b[k], v)) then
+			return false
+		end
+		if (b[k] ~= v) then
+			return false
+		end
 	end
 
 	for k, v in pairs(b) do
-		if a[k] ~= v then return false end
+		if (type(v)=="table") and (not DictEquals(a[k], v)) then
+			return false
+		end
+		if (a[k] ~= v) then
+			return false
+		end
 	end
 
 	return true

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -65,6 +65,12 @@
 	- Vector2
 	- UDim2
 	- UDim
+	- Color3 (0-1)
+	- RGB (0-255)
+	- BrickColor
+	- CFrame
+	- Enum
+	- Rect
 
 	Sample Sheet:
 

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -151,63 +151,7 @@ local DatastoreService = game:GetService("DataStoreService")
 local MessagingService = game:GetService("MessagingService")
 
 local SHA1 = require(script.SHA1)
-
-local TypeTransformer = {
-	["array"] = function(v)
-		return string.split(v,",")
-	end,
-	["dictionary"] = function(v)
-		local values = string.split(v,",")
-		local dict = table.create(#values)
-
-		for _,value in ipairs(values) do
-			local components = string.split(value,"=")
-			dict[string.gsub(string.gsub(components[1],"^ ","")," $","")] = string.gsub(components[2],"^ ","")
-		end
-
-		return dict
-	end,
-	["number"] = function(v)
-		return tonumber(v)
-	end,
-	["boolean"] = function(v)
-		return string.lower(v)=="true" and true or false
-	end,
-	["string"] = function(v)
-		return tostring(v)
-	end,
-	["vector3"] = function(v)
-		local comps = string.split(v,",")
-		return Vector3.new(
-			tonumber(comps[1]) or 0,
-			tonumber(comps[2]) or 0,
-			tonumber(comps[3]) or 0
-		)
-	end,
-	["vector2"] = function(v)
-		local comps = string.split(v,",")
-		return Vector2.new(
-			tonumber(comps[1]) or 0,
-			tonumber(comps[2]) or 0
-		)
-	end,
-	["udim2"] = function(v)
-		local comps = string.split(v,",")
-		return UDim2.new(
-			tonumber(comps[1]) or 0,
-			tonumber(comps[2]) or 0,
-			tonumber(comps[3]) or 0,
-			tonumber(comps[4]) or 0
-		)
-	end,
-	["udim"] = function(v)
-		local comps = string.split(v,",")
-		return UDim.new(
-			tonumber(comps[1]) or 0,
-			tonumber(comps[2]) or 0
-		)
-	end,
-}
+local TypeTransformer = require(script.TypeTransformer)
 
 local function ConvertTyped(Input)
 	local lowerInput = string.lower(Input)

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -29,13 +29,13 @@
 	a SheetManager linked to that sheet. Note that the SheetId parameter is optional and will default to
 	the first (or only) sheet in your spread.
 
-	Your sheet structure is not strictly enforced, but it is strongly recommended that you have a Name column so
+	Your sheet structure is not strictly enforced, but it is STRONGLY recommended that you have a Name column so
 	that it can key your values by Name rather than Row number, making it much easier to work with.
 
-	If you have a boolean or number value, it will attempt to convert the string into your intended value.
-	To create special types, you can explicitly mark them by having the value be "Vector3(1,0,3)"
+	If you have a boolean or number property, it will attempt to convert the string into your intended datatype.
+	To create special types, you can explicitly mark them by having the property be "Type(val)", like "Vector3(1,0,3)"
 
-	Supported explicit value Types (not case sensitive):
+	Supported explicit property Types (not case sensitive):
 	- string (for ensuring a number/boolean remains a string)
 	- array
 	- dictionary
@@ -46,13 +46,13 @@
 
 	Sample Sheet:
 
-	Name                Value                                             Metadata      (Recommend that you freeze Row 1)
-	BoostDirection      Vector3(10, 2, 6.2)                               DescriptorString
-	SpeedMultiplier     0.3                                               CouldEvenPutJSONHereForYourself,tbh
-	DebugEnabled        TRUE                                              MetadataThings
-	ArrayOfStrings      array(firstIndex,secondIndex,thirdIndex)          Point is, you can add any columns or values
-	DictOfKeyedStrings  dictionary(key1=stringvalue,key2=anotherstring)   It's awesome!
-
+	Name                Prop                                              SecondaryProp           AnyPropNameYouLike        [Recommend that you freeze Row 1]
+	BoostDirection      Vector3(10, 2, 6.2)                               100                     10000
+	SpeedMultiplier     0.3 [will autodetect and convert to number]       1                       FALSE
+	DebugEnabled        TRUE [will autodetect and convert to boolean]     JSONstring              you get the point
+	DontAutodetect      string(TRUE) [will NOT convert to boolean]        TRUE                    you can add as many columns as you need
+	ArrayOfStrings      array(firstIndex,secondIndex,thirdIndex)          Vector2(5,2)            and easily set the value type
+	DictOfKeyedStrings  dictionary(key1=stringvalue,key2=anotherstring)   UDim2(0.3,-10,0,350)    it's great!
 
 	API:
 	-------
@@ -84,24 +84,29 @@
 	Name of the service used to retrieve the current SheetManager.Values (Google API, Datastore, Datastore Override, MsgService Subscription)
 	(Used for debugging)
 
-	RBXScriptSignal SheetManager.Changed(newValues: table)
+	RBXScriptSignal SheetManager.Changed(NewValues: table)
 	Fires when SheetManager.Values is changed
 
 	Example:
 	-------
 
-	A good use of live updating values is developing a anticheat system.
-	You can flip a Punishments FFlag so that you can test various methods and thresholds
-	without punishing false positives while you work. Additionally, you can use the
-	sheet values to tweak and swap those methods and thresholds without needing to
-	restart the servers, allowing you to gather analytics and polish your system with ease.
+	A good use of these live updating values is developing a anticheat system.
+	You can flip a have a Value with a property like PunishmentsEnabled so that you can
+	test various methods and thresholds without punishing false positives while you work.
+	Additionally, you can add properties to that Value for thresholds and cheat parameters,
+	so you can fine tune your system without needing to restart the game servers, allowing
+	you to gather analytics and polish your system with ease.
 
+	Sheet used by the Example Code:
+
+	Name                        PunishmentEnabled      Threshold
+	SheetCheat                  FALSE                  35
 
 	local SheetValues = require(script.SheetValues)
 	local AnticheatSheet = SheetValues.new("SPREADSHEET_ID")
 
 	local function PunishCheater(Player)
-		if AnticheatSheet.Values.FFlagPunishmentsDisabled.Value then
+		if not AnticheatSheet.Values.SpeedCheat.PunishmentEnabled then
 			-- Punishments aren't enabled, don't punish
 			return
 		end
@@ -110,7 +115,7 @@
 	end
 
 	local function CheckSpeedCheat(Player)
-		if Speeds[Player] > AnticheatSheet.Values.SpeedCheatThreshold.Value then
+		if Speeds[Player] > AnticheatSheet.Values.SpeedCheat.Threshold then
 			SendAnalytics("SpeedTriggered", Speeds[Player])
 			PunishCheater(Player)
 		end

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -113,16 +113,16 @@
 	-------
 
 	A good use of these live updating values is developing a anticheat system.
-	You can flip a have a Value with a property like PunishmentsEnabled so that you can
+	You can create Values with properties like PunishmentsEnabled so that you can
 	test various methods and thresholds without punishing false positives while you work.
-	Additionally, you can add properties to that Value for thresholds and cheat parameters,
+	Additionally, you can add properties to the Values for thresholds and cheat parameters,
 	so you can fine tune your system without needing to restart the game servers, allowing
 	you to gather analytics and polish your system with ease.
 
 	Sheet used by the Example Code:
 
 	Name                        PunishmentEnabled      Threshold
-	SheetCheat                  FALSE                  35
+	SpeedCheat                  FALSE                  35
 
 	local SheetValues = require(script.SheetValues)
 	local AnticheatSheet = SheetValues.new("SPREADSHEET_ID")

--- a/SheetValues/init.lua
+++ b/SheetValues/init.lua
@@ -29,10 +29,32 @@
 	a SheetManager linked to that sheet. Note that the SheetId parameter is optional and will default to
 	the first (or only) sheet in your spread.
 
-	Your sheet structure is not strictly enforced, but it is STRONGLY recommended that you have a Name column so
-	that it can key your values by Name rather than Row number, making it much easier to work with.
+	What should your Google Sheet look like? How does it translate into Values? Here's the structure:
+	The first row of the Sheet is the Header. This row will NOT become a Value, rather it defines how we parse
+	the subsequent rows into Values. Each entry into row 1 becomes the key for that column, which is called a Property.
 
-	If you have a boolean or number property, it will attempt to convert the string into your intended datatype.
+	Example:
+	Name          PropertyName     AnotherProp
+	TestValue     100              true
+	NextValue     300              false
+
+	This results in two Values being stored and structured like so:
+	SheetManager.Values = {
+		["TestValue"] = {
+			PropertyName = 100,
+			AnotherProp = true
+		},
+		["NextValue"] = {
+			PropertyName = 300,
+			AnotherProp = false
+		},
+	}
+	
+	It's not strictly enforced, but it is STRONGLY recommended that you have a "Name" Property so
+	that it will index your values by Name (will use row number if no Name prop exists), as it is much
+	easier to for you to work with.
+
+	If you have a boolean or number entered, it will attempt to convert the string into your intended datatype.
 	To create special types, you can explicitly mark them by having the property be "Type(val)", like "Vector3(1,0,3)"
 
 	Supported explicit property Types (not case sensitive):
@@ -69,7 +91,7 @@
 	(This is the same as doing `SheetManager.Values.ValueName or DefaultValue` and only exists for style purposes)
 
 	function SheetManager:GetValueChangedSignal(ValueName: string)
-	returns a RBXScriptSignal that fires when the given Value changes, passing two arguements in the fired event (NewValue, OldValue)
+	returns a RBXScriptSignal that fires when the given Value changes, passing two arguments in the fired event (NewValue, OldValue)
 
 	function SheetManager:Destroy()
 	cleans up the SheetManager


### PR DESCRIPTION
Instead of having a column for type that applies to a property column, this update makes the property have the type inside itself. Much better UX and smaller sheets.

Once we no longer need a typing column, then we don't need to enforce a specific sheet structure. This update includes the ability to put any amount of arbitrary properties per Value.

This update also moves the type transformers into a separate file for maintainability and adds a few more types.