### PR TITLE
Supporting Unpublished Places

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
-    "name": "@boatbomber/sheetvalues",
-    "version": "3.0.2",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/boatbomber/SheetValues.git"
-    },
-    "contributors": [
-        "boatbomber"
-    ],
-    "bugs": {
-        "url": "https://github.com/boatbomber/SheetValues/issues"
-    }
+  "name": "@boatbomber/sheetvalues",
+  "version": "3.0.3",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/boatbomber/SheetValues.git"
+  },
+  "contributors": [
+    "boatbomber",
+    "daireb"
+  ],
+  "bugs": {
+    "url": "https://github.com/boatbomber/SheetValues/issues"
+  }
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -404,8 +404,12 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 
 		-- Send these values to all other servers
 		if self.LastSource == "Google API" then
-			local msgSuccess, msgResponse =
-				pcall(MessagingService.PublishAsync, MessagingService, GUID, #json < 1000 and json or "TriggerStore")
+			local msgSuccess, msgResponse = pcall(
+				MessagingService.PublishAsync,
+				MessagingService,
+				GUID,
+				#json < 1000 and json or "TriggerStore"
+			)
 			--if not msgSuccess then warn(msgResponse) end
 		end
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -404,13 +404,12 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 
 		-- Send these values to all other servers
 		if self.LastSource == "Google API" then
-			local msgSuccess, msgResponse = pcall(
+			task.spawn(pcall, 
 				MessagingService.PublishAsync,
 				MessagingService,
 				GUID,
 				#json < 1000 and json or "TriggerStore"
-			)
-			--if not msgSuccess then warn(msgResponse) end
+			)		
 		end
 
 		return true, "Values updated"

--- a/src/init.lua
+++ b/src/init.lua
@@ -258,7 +258,7 @@ local function DictEquals(a, b)
 	return true
 end
 
-local DummyDatastore = {
+local DummyDatastore = { -- Dummy Datastore object to fall back to if DataStoreService fails
 	GetAsync = function()
 		return nil
 	end,

--- a/src/init.lua
+++ b/src/init.lua
@@ -258,6 +258,16 @@ local function DictEquals(a, b)
 	return true
 end
 
+local DummyDatastore = {
+	GetAsync = function()
+		return nil
+	end,
+	SetAsync = function() end,
+	UpdateAsync = function(_, callback)
+		return callback(nil)
+	end,
+}
+
 local SheetValues = {}
 
 function SheetValues.new(SpreadId: string, SheetId: string?)
@@ -270,6 +280,15 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 
 	local ChangedEvent = Instance.new("BindableEvent")
 
+	local dsSuccess, dsReturn = pcall(DatastoreService.GetDataStore, DatastoreService, GUID, "SheetValues")
+	local DataStore
+	if dsSuccess then
+		DataStore = dsReturn
+	else
+		DataStore = DummyDatastore
+		warn("SheetValues: Failed to get DataStore:", dsReturn)
+	end
+
 	local SheetManager = {
 		Changed = ChangedEvent.Event,
 
@@ -278,7 +297,7 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 		Values = {},
 
 		_ValueChangeEvents = {},
-		_DataStore = DatastoreService:GetDataStore(GUID, "SheetValues"),
+		_DataStore = DataStore,
 		_MessageListener = nil,
 		_Alive = true,
 	}
@@ -385,12 +404,8 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 
 		-- Send these values to all other servers
 		if self.LastSource == "Google API" then
-			local msgSuccess, msgResponse = pcall(
-				MessagingService.PublishAsync,
-				MessagingService,
-				GUID,
-				#json < 1000 and json or "TriggerStore"
-			)
+			local msgSuccess, msgResponse =
+				pcall(MessagingService.PublishAsync, MessagingService, GUID, #json < 1000 and json or "TriggerStore")
 			--if not msgSuccess then warn(msgResponse) end
 		end
 
@@ -469,7 +484,7 @@ function SheetValues.new(SpreadId: string, SheetId: string?)
 		table.clear(self)
 	end
 
-	pcall(function()
+	task.spawn(pcall, function()
 		SheetManager._MessageListener = MessagingService:SubscribeAsync(GUID, function(Msg)
 			local msgTimestamp = math.floor(Msg.Sent)
 			if msgTimestamp <= SheetManager.LastUpdated then


### PR DESCRIPTION
I usually edit my games without them being published and SheetValues usually crashes if the DataStore can't be created.

To solve this, I created a dummy DataStore object that the module falls back to if DataStoreService fails (such as in the case of an unpublished game). This means all DataStore requests automatically fail and the module falls back to using pure HttpService.